### PR TITLE
Refactor Calendar

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,15 +4,12 @@
 module Main (main) where
 
 import qualified Brick
-import qualified Brick.Widgets.Edit as Ed
-import Data.Maybe (fromMaybe)
 import qualified Data.Org as O
 import qualified Data.Sequence as Seq
-import Data.Text (Text, isInfixOf, splitOn, unpack)
+import Data.Text (Text, splitOn, unpack)
 import qualified Data.Text.IO as Text
 import Data.Time (Day, defaultTimeLocale, parseTimeM)
 import Lens.Micro
-import Nada.Types hiding (Edit)
 import Nada.App
 import Nada.Org
 import Nada.Types

--- a/src/Nada/App.hs
+++ b/src/Nada/App.hs
@@ -266,11 +266,11 @@ currentModeBar st = str $ show $ st ^. currentMode
 
 -- Scroll functionality for Todo Viewport
 vp0Scroll :: M.ViewportScroll Name
-vp0Scroll = M.viewportScroll mkNadaVP
+vp0Scroll = M.viewportScroll NadaVP
 
 nadaAppDraw :: NadaState -> [Widget Name]
 nadaAppDraw st = case _currentMode st of
-  ModeCalendar -> [drawCalendar (_calendarState st)]
+  ModeCalendar -> [drawCalendar (Calendar NadaCalendar) (Calendar . NadaCalendarDay) (_calendarState st)]
   _            -> [ui]
   where
     ui =
@@ -422,8 +422,7 @@ appEvent ev = do
                   ModeEdit         -> appEventEdit ev
                   ModeEditTag      -> appEventEdit ev
                   ModeEditDeadline -> appEventEdit ev
-                  ModeCalendar     -> appEventCalendar exitCalendar calendarState ev
-                  _                -> return ()
+                  ModeCalendar     -> appEventCalendar calendarState nameToDay exitCalendar ev
   where
     exitCalendar = modify (currentMode .~ ModeNormal)
 

--- a/src/Nada/App.hs
+++ b/src/Nada/App.hs
@@ -266,7 +266,7 @@ vp0Scroll = M.viewportScroll NadaVP
 
 nadaAppDraw :: NadaState -> [Widget Name]
 nadaAppDraw st = case _currentMode st of
-  ModeCalendar -> [drawCalendar (Calendar NadaCalendar) (Calendar . NadaCalendarDay) (_calendarState st)]
+  ModeCalendar -> [drawCalendar (_calendarState st)]
   _            -> [ui]
   where
     ui =
@@ -346,7 +346,7 @@ appEventNormal (VtyEvent vtyE) = case vtyE of
                                                             else i
                                 return ()
   V.EvKey (V.KChar 'c') [] -> do
-                                freshCalendarState <- liftIO $ makeCalendarStateForCurrentDay
+                                freshCalendarState <- liftIO $ makeCalendarStateForCurrentDay nadaCalendarNameConverter
                                 todos <- gets getBareTodosByDate
                                 let cs = freshCalendarState{calendarWidgets = makeCalendarWidgets todos}
                                 modify (calendarState .~ cs)
@@ -420,7 +420,7 @@ appEvent ev = do
                   ModeEdit         -> appEventEdit ev
                   ModeEditTag      -> appEventEdit ev
                   ModeEditDeadline -> appEventEdit ev
-                  ModeCalendar     -> appEventCalendarLens calendarState nameToDay exitCalendar ev
+                  ModeCalendar     -> appEventCalendarLens calendarState exitCalendar ev
   where
     exitCalendar = modify (currentMode .~ ModeNormal)
 

--- a/src/Nada/App.hs
+++ b/src/Nada/App.hs
@@ -420,7 +420,7 @@ appEvent ev = do
                   ModeEdit         -> appEventEdit ev
                   ModeEditTag      -> appEventEdit ev
                   ModeEditDeadline -> appEventEdit ev
-                  ModeCalendar     -> appEventCalendar calendarState nameToDay exitCalendar ev
+                  ModeCalendar     -> appEventCalendarLens calendarState nameToDay exitCalendar ev
   where
     exitCalendar = modify (currentMode .~ ModeNormal)
 

--- a/src/Nada/Calendar.hs
+++ b/src/Nada/Calendar.hs
@@ -50,6 +50,7 @@ makeCalendarStateForCurrentDay = do
   pure $ makeEmptyCalendarStateFromDay day
  
 
+-- TODO: Make header clickable to adjust month/year + add keybindings for that
 drawCalendar :: Ord n => n -> (Day -> n) -> CalendarState n -> Widget n
 drawCalendar _calendarName dayToName state@CalendarState{..} = header <=> drawCalendarBody dayToName state <=> footer
   where

--- a/src/Nada/Org.hs
+++ b/src/Nada/Org.hs
@@ -39,8 +39,8 @@ orgFileToNada :: O.OrgFile -> IO NadaState
 -- returning 'Nothing').
 -- Reserved 0 - 9 for other clickable widgets.
 orgFileToNada org = do
-  calendarState <- makeCalendarStateForCurrentDay
-  let (newState, assignedIds) = addTodosToState (defaultNadaStateFromCalendarState calendarState) correctlyParsedTodos
+  cs <- makeCalendarStateForCurrentDay nadaCalendarNameConverter
+  let (newState, assignedIds) = addTodosToState (defaultNadaStateFromCalendarState cs) correctlyParsedTodos
   pure (newState & (visibleTodoLists.ix 0.todoList) .~ Seq.fromList assignedIds
                  & allTags .~ Data.Set.toList tags)
   where

--- a/src/Nada/Org.hs
+++ b/src/Nada/Org.hs
@@ -84,7 +84,7 @@ orgSectionToNadaTodo (tdId, O.Section{..}) = do
     -- The more natural thing to do would be to just return the largest id from
     -- 'orgFileToNada'. Or eventually rework this function to make use of
     -- our function to create a new todo (once implemented).
-    , _todoId = mkTodoId tdId
+    , _todoId = TodoId tdId
     , _todoDueDate  = dueDate
     , _todoPriority = priority
     , _todoTags = sectionTags

--- a/src/Nada/Types.hs
+++ b/src/Nada/Types.hs
@@ -16,7 +16,6 @@ import qualified Brick.Widgets.Edit as Ed
 import Lens.Micro
 import Lens.Micro.GHC ()
 import Lens.Micro.TH (makeLenses)
-import Data.Time (Day)
 import Nada.Calendar (CalendarState(..))
 
 data NadaCalendar

--- a/src/Nada/Types.hs
+++ b/src/Nada/Types.hs
@@ -16,23 +16,24 @@ import qualified Brick.Widgets.Edit as Ed
 import Lens.Micro
 import Lens.Micro.GHC ()
 import Lens.Micro.TH (makeLenses)
-import Nada.Calendar (CalendarState(..))
-
-data NadaCalendar
-  = NadaCalendar
-  | NadaCalendarDay Day
-  deriving (Eq, Show, Ord)
+import Nada.Calendar (CalendarState(..), CalendarName, CalendarNameConverter(..))
 
 data Name
   = TodoId Integer
   | TodoEditor
   | NadaVP
-  | Calendar NadaCalendar
+  | Calendar CalendarName
   deriving (Eq, Show, Ord)
 
-nameToDay :: Name -> Maybe Day
-nameToDay (Calendar (NadaCalendarDay d)) = Just d
-nameToday _ = Nothing
+nadaMatchCalendarName :: Name -> Maybe CalendarName
+nadaMatchCalendarName (Calendar cn) = Just cn
+nadaMatchCalendarName _ = Nothing
+
+nadaCalendarNameConverter :: CalendarNameConverter Name
+nadaCalendarNameConverter = CalendarNameConverter
+  { matchCalendarName = nadaMatchCalendarName
+  , toResourceName = Calendar
+  }
 
 data NadaPriority = High
                   | Medium 

--- a/test/Test/Nada/Calendar.hs
+++ b/test/Test/Nada/Calendar.hs
@@ -14,6 +14,7 @@ import Data.Time.Calendar.OrdinalDate
 import Test.Tasty
 import Test.Tasty.QuickCheck as QC
 import Test.Tasty.HUnit
+import Nada.Calendar (firstDayOfWeekOnBefore)
 
 newtype TestCalendarState n = TestCalendarState (CalendarState n)
 
@@ -37,9 +38,9 @@ genMonth = MkMonth <$> chooseInteger (1, 100000)
 genCalendarState :: QC.Gen (TestCalendarState n)
 genCalendarState = TestCalendarState . makeEmptyCalendarStateFromDay <$> genDay
 
-propFirstMondayBeforeValid :: Property
-propFirstMondayBeforeValid = forAll genDay $ \day ->
-  let monday = firstMondayBefore day
+propFirstDayOfWeekOnBeforeValid :: Property
+propFirstDayOfWeekOnBeforeValid = forAll genDay $ \day ->
+  let monday = firstDayOfWeekOnBefore Monday day
    in -- Is a Monday
       dayOfWeek monday == Monday
       -- Is the first preceding
@@ -76,7 +77,7 @@ propPrevNextDayInverse = forAll genCalendarState $ \(TestCalendarState cs) ->
   (calendarSelectedDate cs) == (calendarSelectedDate . prevDay . nextDay $ cs)
 
 propertyTests = testGroup "Property tests"
-  [ QC.testProperty "firsMondayBefore" propFirstMondayBeforeValid
+  [ QC.testProperty "firstDayOfWeekOnBefore" propFirstDayOfWeekOnBeforeValid
   , QC.testProperty "calendarBlockRange" propCalendarBlockRangeValid
   , QC.testProperty "prevSelectedMonth . nextSelectedMonth == id" propPrevNextSelectedMonthInverse
   , QC.testProperty "nextSelectedMonth does not change selected date" propPrevNextMonthDoesNotChangeDay


### PR DESCRIPTION
# Goals

This PR mainly serves to refactor `Calendar.hs` in order to make it suitable as a standalone library. An additional goal is that the calendar view should be 100% navigable with only a mouse or a keyboard.

# Changes

1. I've refactored the types to make it easier to integrate with. Now a user of the `Calendar` widget only needs to provide details on how to make `Widget`s from `Day`s, how to name the Calendar and its cells, and a setter for the `CalendarState n` in the overall state. Although I'm trying to remove the last requirement.
2. I've cleaned up the UI so that the borders connect on dates and highlighting selected dates works as intended.
3. I've fixed up moving along the calendar.

# Open problems

## Keybinds

I wanted to have two behaviors depending on how you interacted with the app.

### Mouse

With a mouse, my thought was that you could select a date but scroll through the months/years without changing the selection. So mwheel down/up change the selected month but not the cursor.

### Keyboard

With the keyboard, I thought of navigation as moving the selected date (which I'll call the cursor since that's how I think of it). So `C-u`/`C-d` would move the date to the next month. There is some sophisticated logic that involves preserving the relative location of the cursor so the jump isn't visually awkward.

However, this leads to some obvious dissonance if you want to combine the two. Right now I'm leaning toward just adding keyboard shortcuts for both moving the cursor and moving the selected month. Which works fine if you want to peer into the future, but then suddenly if you hit `hjkl` you're back to the cursor.

So to resolve that issue I see three ways forward

1. Make `hjkl` "smart" so that the cursor jumps to your current month if you use them. This is a decent UX but potentially will lose your place if you hit these keys by accident.
2. Keep `hjkl` "dumb" and let you jump back to them, but also give a keybind to bring the cursor to the current view.
3. Make the mouse move the cursor in some predictable way and don't give the option to change the selected month without changing the cursor.

I'm leaning toward the last one, but there definitely are options here.

## Selecting dates

Previously I was thinking of only being able to select a single date and the selected date was the cursor for the keyboard mode. But actually it makes sense to allow for customization on how selections work.

Probably we should allow the user of `Calendar` to specify whether they want to allow selection of dates and also provide some keybinds such as

### Mouse
- Shift click down: starts selecting range
- Shift click up: ends selecting range
- Cmd/Meta click: selects single day
- Left click: selects single day, clearing previous selection
- Alternatively, shift click could be a toggle where the first time you click it selects the first date and the second time you click it completes the range.

### Keyboard
- `a`: select all days in the month
- `s`: select single day
- `u`: clear selection
- `v`: start range select (similar to visual mode) - hitting `RET`/`v` confirms the selection and `ESC` exits.

We'd then need to extend the state with some fields indicating what state the calendar is in (e.g. select mode, normal mode), what dates are selected, and whether selection is allowed (or how it's limited). We could also include a function that would indicate whether a selection is valid/invalid and export some standard ones like a rangeSelector, singleDay, etc.

Selections and the cursor will need different stylings too.

# To-dos

- [x] Edit month
- [x] Edit year
- [ ] Selection
- [ ] Fix up styling (right now uses a hardcoded attribute from the main app)